### PR TITLE
Fixes for Perl >= 5.26

### DIFF
--- a/about_defined.pl
+++ b/about_defined.pl
@@ -51,7 +51,7 @@ sub about_defined {
     
     my @bar;
     
-    is (defined @bar,  __, 'declared variables initialize to undef -- part 2');
+    is (@bar,  __, 'declared variables initialize to undef -- part 2');
     is (defined $#bar, __, 'declared variables initialize to undef -- part 3');
     
     @bar = (27, 42, undef);

--- a/road_to_illumination.pl
+++ b/road_to_illumination.pl
@@ -33,6 +33,9 @@ package Perl::Koans;
 use strict;
 use warnings;
 
+use FindBin 1.51 qw( $RealBin );
+use lib $RealBin;
+
 use lib './lib';
 use Perl::Koans qw(bail print_illumination);
 


### PR DESCRIPTION
Koans fail to run because of the following issues:

`Can't locate about_koans.pl in @INC` – more info about it [here](https://stackoverflow.com/a/46549774/4606884). I've fixed this.

`Can't use 'defined(@array)' (Maybe you should just omit the defined()?)` – `defined` is not needed for array anymore, since v5.22, so I removed this.

Now it works correctly on recent version of Perl.

My env:
```
This is perl 5, version 28, subversion 0 (v5.28.0) built for darwin-thread-multi-2level

Copyright 1987-2018, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at http://www.perl.org/, the Perl Home Page.
```